### PR TITLE
Add null check to websocket

### DIFF
--- a/src/main/java/io/github/sac/Socket.java
+++ b/src/main/java/io/github/sac/Socket.java
@@ -540,8 +540,8 @@ public class Socket extends Emitter {
         return ws.getState();
     }
 
-    public Boolean isconnected(){
-        return ws.getState()==WebSocketState.OPEN;
+    public Boolean isconnected() {
+        return ws != null && ws.getState() == WebSocketState.OPEN;
     }
 
     public void disableLogging(){


### PR DESCRIPTION
If the socket is connected inside a service and the application is terminated by removing the app from the recents, the socket is not null but the WebSocket becomes null. So checking is connected causes a null pointer exception.