### PR TITLE
Fix NPE when calling disconnect()

### DIFF
--- a/src/main/java/io/github/sac/Socket.java
+++ b/src/main/java/io/github/sac/Socket.java
@@ -522,7 +522,9 @@ public class Socket extends Emitter {
     }
 
     public void disconnect() {
-        ws.disconnect();
+        if (ws != null) {
+            ws.disconnect();
+        }
         strategy = null;
     }
 


### PR DESCRIPTION
When calling `disconnect()` `ws` reference may be null, and the following exception might be raised:
```java
ava.lang.NullPointerException: Attempt to invoke virtual method 'com.neovisionaries.ws.client.WebSocket com.neovisionaries.ws.client.WebSocket.disconnect()' on a null object reference
        at android.app.ActivityThread.handleUnbindService(ActivityThread.java:3473)
        at android.app.ActivityThread.-wrap27(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1693)
        at android.os.Handler.dispatchMessage(Handler.java:105)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6541)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'com.neovisionaries.ws.client.WebSocket com.neovisionaries.ws.client.WebSocket.disconnect()' on a null object reference
        at io.github.sac.Socket.disconnect(Socket.java:546)
```