### PR TITLE
Avoid creating new socket every time on connectAsync

### DIFF
--- a/src/main/java/io/github/sac/Socket.java
+++ b/src/main/java/io/github/sac/Socket.java
@@ -490,7 +490,7 @@ public class Socket extends Emitter {
                 reconnect();
             }
         }else{
-            logger.warning("Unable to connect: there is an active connection maybe?");
+            logger.warning("Unable to connect: there is an active connection");
         }
 
     }
@@ -511,7 +511,7 @@ public class Socket extends Emitter {
             ws.addListener(adapter);
             ws.connectAsynchronously();
         }else{
-            logger.warning("Unable to connect: there is an active connection maybe?");
+            logger.warning("Unable to connect: there is an active connection");
         }
     }
 


### PR DESCRIPTION
For every call to connect/connectAsync there is a new ws socket created, leaving the previous one connected but orphaned.
This PR, allow only one instance of Socket to be actively connected at any time.